### PR TITLE
chore: add extra storage for bastion

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -62,6 +62,7 @@ module "ec2_instance" {
   associate_public_ip_address = true
   user_data                   = data.template_file.user_data.rendered
   tags                        = var.tags
+  root_block_device           = [ { volume_size = "180",volume_type = "gp3",delete_on_termination = true,}, ]
 
   depends_on = [
     module.vpc


### PR DESCRIPTION
Adding storage rather than the default 8gb from the ami